### PR TITLE
Added advanced filter feature

### DIFF
--- a/data/addressbook.json
+++ b/data/addressbook.json
@@ -9,10 +9,10 @@
   }, {
     "name" : "Healthy Duck Brown Rice",
     "time" : "20",
-    "isFavourite" : false,
+    "isFavourite" : true,
     "ingredients" : [ "Brown rice,  300.0, grain", "Duck,  100.0, protein" ],
     "steps" : [ "Braise the duck and eggs", "Steam brown rice with herbs", "Serve while hot" ],
-    "goals" : [ "Wholesome Wholegrains", "Bulk like the Hulk" ]
+    "goals" : [ "Bulk like the Hulk", "Wholesome Wholegrains" ]
   }, {
     "name" : "Final Recipe",
     "time" : "33",

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -15,28 +15,28 @@ import seedu.address.model.Model;
 import seedu.address.model.recipe.Recipe;
 
 /**
- * Adds a recipe to the address book.
+ * Adds a recipe to the recipe book.
  */
 public class AddCommand extends Command {
 
     public static final String COMMAND_WORD = "add";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a recipe to the address book. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a recipe to the address book.\n"
             + "Parameters: "
             + PREFIX_NAME + "NAME "
             + PREFIX_TIME + "TIME "
-            + "[" + PREFIX_INGREDIENT_GRAIN + "GRAIN]..."
-            + "[" + PREFIX_INGREDIENT_VEGE + "VEGETABLE]..."
-            + "[" + PREFIX_INGREDIENT_PROTEIN + "PROTEIN]..."
-            + "[" + PREFIX_INGREDIENT_OTHER + "OTHER]..."
+            + "[" + PREFIX_INGREDIENT_GRAIN + "GRAIN]... "
+            + "[" + PREFIX_INGREDIENT_VEGE + "VEGETABLE]... "
+            + "[" + PREFIX_INGREDIENT_PROTEIN + "PROTEIN]... "
+            + "[" + PREFIX_INGREDIENT_OTHER + "OTHER]... "
             + "[" + PREFIX_STEP + "STEP]... "
             + "[" + PREFIX_GOAL + "GOAL]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "Caesar Salad "
             + PREFIX_TIME + "10 "
-            + PREFIX_INGREDIENT_VEGE + "100, Tomato"
-            + PREFIX_INGREDIENT_VEGE + "100, Lettuce"
-            + PREFIX_INGREDIENT_OTHER + "50, Honeydew"
+            + PREFIX_INGREDIENT_VEGE + "100, Tomato "
+            + PREFIX_INGREDIENT_VEGE + "100, Lettuce "
+            + PREFIX_INGREDIENT_OTHER + "50, Honeydew "
             + PREFIX_STEP + "Cut tomatoes "
             + PREFIX_STEP + "Remove honeydew skin "
             + PREFIX_GOAL + "Herbivore ";
@@ -51,7 +51,7 @@ public class AddCommand extends Command {
      */
     public AddCommand(Recipe recipe) {
         requireNonNull(recipe);
-        toAdd = recipe;
+        this.toAdd = recipe;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -12,7 +12,7 @@ import seedu.address.model.Model;
 import seedu.address.model.recipe.Recipe;
 
 /**
- * Deletes a recipe identified using it's displayed index from the reipe book.
+ * Deletes a recipe identified using it's displayed index from the recipe book.
  */
 public class DeleteCommand extends Command {
 

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -12,7 +12,7 @@ import seedu.address.model.Model;
 import seedu.address.model.recipe.Recipe;
 
 /**
- * Deletes a recipe identified using it's displayed index from the address book.
+ * Deletes a recipe identified using it's displayed index from the reipe book.
  */
 public class DeleteCommand extends Command {
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -34,7 +34,7 @@ import seedu.address.model.recipe.Time;
 import seedu.address.model.recipe.ingredient.Ingredient;
 
 /**
- * Edits the details of an existing recipe in the address book.
+ * Edits the details of an existing recipe in the recipe book.
  */
 public class EditCommand extends Command {
 
@@ -46,18 +46,18 @@ public class EditCommand extends Command {
             + "Parameters: INDEX (must be a positive integer) "
             + "[" + PREFIX_NAME + "NAME] "
             + "[" + PREFIX_TIME + "TIME] "
-            + "[" + PREFIX_INGREDIENT_GRAIN + "GRAIN]..."
-            + "[" + PREFIX_INGREDIENT_VEGE + "VEGETABLE]..."
-            + "[" + PREFIX_INGREDIENT_PROTEIN + "PROTEIN]..."
-            + "[" + PREFIX_INGREDIENT_OTHER + "OTHER]..."
+            + "[" + PREFIX_INGREDIENT_GRAIN + "GRAIN]... "
+            + "[" + PREFIX_INGREDIENT_VEGE + "VEGETABLE]... "
+            + "[" + PREFIX_INGREDIENT_PROTEIN + "PROTEIN]... "
+            + "[" + PREFIX_INGREDIENT_OTHER + "OTHER]... "
             + "[" + PREFIX_STEP + "STEP]... "
             + "[" + PREFIX_GOAL + "GOAL]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_TIME + "10 "
-            + PREFIX_INGREDIENT_VEGE + "Insert new vegetable here."
-            + PREFIX_INGREDIENT_PROTEIN + "Insert new protein-rich ingredient here."
-            + PREFIX_STEP + "Insert new step here."
-            + PREFIX_GOAL + "Insert new goal here.";
+            + PREFIX_INGREDIENT_VEGE + "Insert new vegetable here "
+            + PREFIX_INGREDIENT_PROTEIN + "Insert new protein-rich ingredient here "
+            + PREFIX_STEP + "Insert new step here "
+            + PREFIX_GOAL + "Insert new goal here ";
 
     public static final String MESSAGE_EDIT_RECIPE_SUCCESS = "Edited Recipe: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";

--- a/src/main/java/seedu/address/logic/commands/FavouriteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FavouriteCommand.java
@@ -13,7 +13,7 @@ import seedu.address.model.Model;
 import seedu.address.model.recipe.Recipe;
 
 /**
- * Favourites a recipe identified using it's displayed index from the address book.
+ * Favourites a recipe identified using it's displayed index from the recipe book.
  */
 public class FavouriteCommand extends Command {
     public static final String COMMAND_WORD = "favourite";

--- a/src/main/java/seedu/address/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterCommand.java
@@ -1,0 +1,59 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_GOAL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INGREDIENT_GRAIN;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INGREDIENT_OTHER;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INGREDIENT_PROTEIN;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INGREDIENT_VEGE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TIME;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.recipe.RecipeMatchesKeywordsPredicate;
+
+/**
+ * Finds and lists all recipes in recipe book that matches the specified arguments.
+ * Keyword matching is case insensitive.
+ */
+public class FilterCommand extends Command {
+
+    public static final String COMMAND_WORD = "filter";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all recipes that matches the "
+            + "specified arguments (case-insensitive) and displays them as a list with index numbers.\n"
+            + "Parameters: favourites "
+            + "[" + PREFIX_TIME + "TIME (upperbound) or TIME RANGE (lowerbound-upperbound)] "
+            + "[" + PREFIX_INGREDIENT_GRAIN + "GRAIN]... "
+            + "[" + PREFIX_INGREDIENT_VEGE + "VEGETABLE]... "
+            + "[" + PREFIX_INGREDIENT_PROTEIN + "PROTEIN]... "
+            + "[" + PREFIX_INGREDIENT_OTHER + "OTHER]... "
+            + "[" + PREFIX_GOAL + "GOAL]...\n"
+            + "Example: " + COMMAND_WORD + " favourites "
+            + PREFIX_TIME + "10-20 "
+            + PREFIX_INGREDIENT_VEGE + "Search for vegetable "
+            + PREFIX_INGREDIENT_PROTEIN + "Search for protein-rich ingredient "
+            + PREFIX_GOAL + "Search for goal ";
+
+    private final RecipeMatchesKeywordsPredicate predicate;
+
+    public FilterCommand(RecipeMatchesKeywordsPredicate predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredRecipeList(predicate);
+        return new CommandResult(
+                String.format(Messages.MESSAGE_RECIPES_LISTED_OVERVIEW, model.getFilteredRecipeList().size()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof FilterCommand // instanceof handles nulls
+                && predicate.equals(((FilterCommand) other).predicate)); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -7,7 +7,7 @@ import seedu.address.model.Model;
 import seedu.address.model.recipe.NameContainsKeywordsPredicate;
 
 /**
- * Finds and lists all recipes in address book whose name contains any of the argument keywords.
+ * Finds and lists all recipes in recipe book whose name contains any of the argument keywords.
  * Keyword matching is case insensitive.
  */
 public class FindCommand extends Command {

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -6,7 +6,7 @@ import static seedu.address.model.Model.PREDICATE_SHOW_ALL_RECIPES;
 import seedu.address.model.Model;
 
 /**
- * Lists all recipes in the address book to the user.
+ * Lists all recipes in the recipe book to the user.
  */
 public class ListCommand extends Command {
 

--- a/src/main/java/seedu/address/logic/commands/UnfavouriteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnfavouriteCommand.java
@@ -13,7 +13,7 @@ import seedu.address.model.Model;
 import seedu.address.model.recipe.Recipe;
 
 /**
- * Unfavourites a recipe identified using it's displayed index from the address book.
+ * Unfavourites a recipe identified using it's displayed index from the recipe book.
  */
 public class UnfavouriteCommand extends Command {
     public static final String COMMAND_WORD = "unfavourite";

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -25,8 +25,8 @@ import seedu.address.logic.commands.EditCommand.EditRecipeDescriptor;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.goal.Goal;
 import seedu.address.model.recipe.Step;
-
 import seedu.address.model.recipe.ingredient.Ingredient;
+
 /**
  * Parses input arguments and creates a new EditCommand object
  */

--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -1,0 +1,97 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_GOAL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INGREDIENT_GRAIN;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INGREDIENT_OTHER;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INGREDIENT_PROTEIN;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INGREDIENT_VEGE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TIME;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import seedu.address.logic.commands.FilterCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.goal.Goal;
+import seedu.address.model.recipe.RecipeMatchesKeywordsPredicate;
+import seedu.address.model.recipe.Time;
+
+/**
+ * Parses input arguments and creates a new FilterCommand object
+ */
+public class FilterCommandParser implements Parser<FilterCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the FilterCommand
+     * and returns a FilterCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public FilterCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_TIME, PREFIX_INGREDIENT_GRAIN, PREFIX_INGREDIENT_VEGE,
+                        PREFIX_INGREDIENT_PROTEIN, PREFIX_INGREDIENT_OTHER, PREFIX_GOAL);
+
+        List<Time> filterByTime;
+        if (argMultimap.getValue(PREFIX_TIME).isPresent()) {
+            filterByTime = parseTimeForFilter(argMultimap.getValue(PREFIX_TIME).get());
+        } else {
+            filterByTime = Collections.emptyList();
+        }
+
+        Set<Goal> filterByGoals;
+        if (!argMultimap.getAllValues(PREFIX_GOAL).isEmpty()) {
+            filterByGoals = parseGoalsForFilter(argMultimap.getAllValues(PREFIX_GOAL));
+            System.out.println(argMultimap.getAllValues(PREFIX_GOAL));
+        } else {
+            filterByGoals = Collections.emptySet();
+        }
+
+        boolean filterByFavourites = false;
+        if (argMultimap.getPreamble().toLowerCase().equals("favourites")) {
+            filterByFavourites = true;
+        }
+
+        if (!isValidPredicates(filterByTime, filterByGoals, filterByFavourites)) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));
+        }
+
+        return new FilterCommand(new RecipeMatchesKeywordsPredicate(filterByTime, filterByGoals, filterByFavourites));
+    }
+
+    /**
+     * Returns true if there are predicates (arguments) in the user's input to filter the recipe book by.
+     */
+    private boolean isValidPredicates(List<Time> time, Set<Goal> goals, boolean favourites) {
+        return !time.isEmpty() || !goals.isEmpty() || favourites;
+    }
+
+    /**
+     * Parses {@code Collection<String> goals} into a {@code Set<Goal>} if {@code goals} is non-empty.
+     * If {@code goals} contain only one element which is an empty string, it will be parsed into a
+     * {@code Set<Goal>} containing zero goals.
+     */
+    private Set<Goal> parseGoalsForFilter(Collection<String> goals) throws ParseException {
+        assert goals != null;
+        Collection<String> goalSet = goals.size() == 1 && goals.contains("")
+                ? Collections.emptySet()
+                : goals;
+        return ParserUtil.parseGoals(goalSet);
+    }
+
+    /**
+     * Parses {@code String time} into a {@code List<Time>} if {@code time} is non-empty.
+     */
+    private List<Time> parseTimeForFilter(String time) throws ParseException {
+        assert time != null;
+        return time.equals("")
+                ? Collections.emptyList()
+                : Arrays.asList(ParserUtil.parseTimeRange(time));
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -47,7 +47,6 @@ public class FilterCommandParser implements Parser<FilterCommand> {
         Set<Goal> filterByGoals;
         if (!argMultimap.getAllValues(PREFIX_GOAL).isEmpty()) {
             filterByGoals = parseGoalsForFilter(argMultimap.getAllValues(PREFIX_GOAL));
-            System.out.println(argMultimap.getAllValues(PREFIX_GOAL));
         } else {
             filterByGoals = Collections.emptySet();
         }

--- a/src/main/java/seedu/address/logic/parser/RecipeBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/RecipeBookParser.java
@@ -13,6 +13,7 @@ import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FavouriteCommand;
+import seedu.address.logic.commands.FilterCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
@@ -75,6 +76,9 @@ public class RecipeBookParser {
 
         case UnfavouriteCommand.COMMAND_WORD:
             return new UnfavouriteCommandParser().parse(arguments);
+
+        case FilterCommand.COMMAND_WORD:
+            return new FilterCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/model/goal/Goal.java
+++ b/src/main/java/seedu/address/model/goal/Goal.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
 /**
- * Represents a Goal in the address book.
+ * Represents a Goal in the recipe book.
  * Guarantees: immutable; name is valid as declared in {@link #isValidGoalName(String)}
  */
 public class Goal {
@@ -36,12 +36,12 @@ public class Goal {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof Goal // instanceof handles nulls
-                && goalName.equals(((Goal) other).goalName)); // state check
+                && goalName.toLowerCase().equals(((Goal) other).goalName.toLowerCase())); // state check
     }
 
     @Override
     public int hashCode() {
-        return goalName.hashCode();
+        return goalName.toLowerCase().hashCode();
     }
 
     /**

--- a/src/main/java/seedu/address/model/recipe/Name.java
+++ b/src/main/java/seedu/address/model/recipe/Name.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
 /**
- * Represents a Recipe's name in the address book.
+ * Represents a Recipe's name in the recipe book.
  * Guarantees: immutable; is valid as declared in {@link #isValidName(String)}
  */
 public class Name {
@@ -28,7 +28,7 @@ public class Name {
     public Name(String name) {
         requireNonNull(name);
         checkArgument(isValidName(name), MESSAGE_CONSTRAINTS);
-        fullName = name;
+        this.fullName = name;
     }
 
     /**

--- a/src/main/java/seedu/address/model/recipe/Recipe.java
+++ b/src/main/java/seedu/address/model/recipe/Recipe.java
@@ -14,7 +14,7 @@ import seedu.address.model.goal.Goal;
 import seedu.address.model.recipe.ingredient.Ingredient;
 
 /**
- * Represents a Recipe in the address book.
+ * Represents a Recipe in the recipe book.
  * Guarantees: details are present and not null, field values are validated, immutable.
  */
 public class Recipe {
@@ -43,7 +43,7 @@ public class Recipe {
         this.isFavourite = isFavourite;
     }
 
-    public boolean getFavouriteStatus() {
+    public boolean isFavourite() {
         return isFavourite;
     }
 

--- a/src/main/java/seedu/address/model/recipe/RecipeMatchesKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/recipe/RecipeMatchesKeywordsPredicate.java
@@ -45,7 +45,8 @@ public class RecipeMatchesKeywordsPredicate implements Predicate<Recipe> {
         return other == this // short circuit if same object
                 || (other instanceof RecipeMatchesKeywordsPredicate // instanceof handles nulls
                 && time.equals(((RecipeMatchesKeywordsPredicate) other).time)
-                && goals.equals(((RecipeMatchesKeywordsPredicate) other).goals)); // state check
+                && goals.equals(((RecipeMatchesKeywordsPredicate) other).goals)
+                && favourites == ((RecipeMatchesKeywordsPredicate) other).favourites); // state check
     }
 
 }

--- a/src/main/java/seedu/address/model/recipe/RecipeMatchesKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/recipe/RecipeMatchesKeywordsPredicate.java
@@ -1,0 +1,51 @@
+package seedu.address.model.recipe;
+
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import seedu.address.model.goal.Goal;
+
+/**
+ * Tests that a {@code Recipe}'s {@code Time}, {@code Ingredient}, or {@code Goal} matches any of the arguments given.
+ */
+public class RecipeMatchesKeywordsPredicate implements Predicate<Recipe> {
+    private final List<Time> time;
+    private final Set<Goal> goals;
+    private final boolean favourites;
+
+    public RecipeMatchesKeywordsPredicate(List<Time> time, Set<Goal> goals, boolean favourites) {
+        this.time = time;
+        this.goals = goals;
+        this.favourites = favourites;
+    }
+
+    @Override
+    public boolean test(Recipe recipe) {
+        boolean toFilter = true;
+        if (time.size() == 1) {
+            toFilter = toFilter && time.get(0).isLessThan(recipe.getTime());
+        } else if (time.size() == 2) {
+            toFilter = toFilter && recipe.getTime().isWithinRange(time.get(0), time.get(1));
+        }
+
+        if (!goals.isEmpty()) {
+            toFilter = toFilter && goals.stream().anyMatch(goal -> recipe.getGoals().contains(goal));
+        }
+
+        if (favourites) {
+            toFilter = toFilter && recipe.isFavourite();
+        }
+
+        return toFilter;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof RecipeMatchesKeywordsPredicate // instanceof handles nulls
+                && time.equals(((RecipeMatchesKeywordsPredicate) other).time)
+                && goals.equals(((RecipeMatchesKeywordsPredicate) other).goals)); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/model/recipe/Step.java
+++ b/src/main/java/seedu/address/model/recipe/Step.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
 /**
- * Represents a Recipe's step in the address book.
+ * Represents a Recipe's step in the recipe book.
  * Guarantees: immutable; is valid as declared in {@link #isValidStep(String)}
  */
 public class Step {
@@ -22,7 +22,7 @@ public class Step {
     public Step(String step) {
         requireNonNull(step);
         checkArgument(isValidStep(step), MESSAGE_CONSTRAINTS);
-        value = step;
+        this.value = step;
     }
 
     /**

--- a/src/main/java/seedu/address/model/recipe/Time.java
+++ b/src/main/java/seedu/address/model/recipe/Time.java
@@ -4,14 +4,17 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
 /**
- * Represents a Recipe's time number in the address book.
+ * Represents a Recipe's time number in the recipe book.
  * Guarantees: immutable; is valid as declared in {@link #isValidTime(String)}
  */
 public class Time {
 
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Time should only contain numbers in terms of minutes, and it should be at least 1 digit long";
+            "Time should only contain whole numbers in terms of minutes, and it should be at least 1 digit long";
+    public static final String TIME_RANGE_CONSTRANTS = "Time or time range should only contain whole numbers in terms "
+            + "of minutes, be at least 1 digit long, and be separated by a single dash.\n"
+            + "Example: filter t/10 or filter t/10-20";
     public static final String VALIDATION_REGEX = "\\d{1,}";
     public final String value;
 
@@ -23,7 +26,7 @@ public class Time {
     public Time(String time) {
         requireNonNull(time);
         checkArgument(isValidTime(time), MESSAGE_CONSTRAINTS);
-        value = time;
+        this.value = time;
     }
 
     /**
@@ -31,6 +34,23 @@ public class Time {
      */
     public static boolean isValidTime(String test) {
         return test.matches(VALIDATION_REGEX);
+    }
+
+    /**
+     * Returns true if the value of the given time object is less than or equal to the value of this time object.
+     */
+    public boolean isLessThan(Time time) {
+        return Integer.parseInt(time.value) <= Integer.parseInt(value);
+    }
+
+    /**
+     * Returns true if the value of this time object is within the range of the values of the given lower and upper
+     * bound time objects.
+     */
+    public boolean isWithinRange(Time lowerBound, Time upperBound) {
+        int valueAsInt = Integer.parseInt(value);
+        return valueAsInt >= Integer.parseInt(lowerBound.value)
+                && valueAsInt <= Integer.parseInt(upperBound.value);
     }
 
     @Override

--- a/src/main/java/seedu/address/storage/JsonAdaptedRecipe.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedRecipe.java
@@ -62,7 +62,7 @@ class JsonAdaptedRecipe {
     public JsonAdaptedRecipe(Recipe source) {
         name = source.getName().fullName;
         time = source.getTime().value;
-        isFavourite = source.getFavouriteStatus();
+        isFavourite = source.isFavourite();
         ingredients.addAll(source.getIngredients().stream()
                 .map(JsonAdaptedIngredient::new)
                 .collect(Collectors.toList()));

--- a/src/main/java/seedu/address/ui/RecipeCard.java
+++ b/src/main/java/seedu/address/ui/RecipeCard.java
@@ -61,7 +61,7 @@ public class RecipeCard extends UiPart<Region> {
 
         time.setText(recipe.getTime().value + " min");
 
-        if (recipe.getFavouriteStatus()) {
+        if (recipe.isFavourite()) {
             Path favouriteIconPath = Paths.get("src", "main", "resources", "images", "favourite.png");
             favourite.setImage(new Image(Files.newInputStream(favouriteIconPath)));
         }

--- a/src/main/java/seedu/address/ui/ResultDisplay.java
+++ b/src/main/java/seedu/address/ui/ResultDisplay.java
@@ -23,6 +23,7 @@ public class ResultDisplay extends UiPart<Region> {
     public void setFeedbackToUser(String feedbackToUser) {
         requireNonNull(feedbackToUser);
         resultDisplay.setText(feedbackToUser);
+        resultDisplay.setWrapText(true);
     }
 
 }

--- a/src/test/java/seedu/address/testutil/RecipeBuilder.java
+++ b/src/test/java/seedu/address/testutil/RecipeBuilder.java
@@ -52,7 +52,7 @@ public class RecipeBuilder {
     public RecipeBuilder(Recipe recipeToCopy) {
         name = recipeToCopy.getName();
         time = recipeToCopy.getTime();
-        isFavourite = recipeToCopy.getFavouriteStatus();
+        isFavourite = recipeToCopy.isFavourite();
         ingredients = recipeToCopy.getIngredients();
         steps = recipeToCopy.getSteps();
         goals = new HashSet<>(recipeToCopy.getGoals());


### PR DESCRIPTION
Implemented majority of the Advanced Filter feature. Will enhance this feature when the `Ingredient` classes are fully implemented and integrated into the `Recipe`.

Currently, the filter command's capabilities are as follows:

`filter` `favourites` `t/upperbound` or `t/lowerbound-upperbound` `g/goal 1` `g/goal 2`

Example: `filter favourites t/20 g/Bulk like the Hulk` or `filter t/15-25 g/Herbivore`
Similar to the edit command, the user only needs to include whichever arguments he wants to filter by.

Things to note:
1) `favourites` must be the first argument if the user wants to filter by favourites and it is not case sensitive.
2) If the user wants to filter by a _range_ of time (eg. he wants to get recipes that will take between 20 and 30 minutes), the delimiter used must be a dash "-". Spaces are alright, they won't affect parsing.
3) If the user doesn't filter by a _range_ of time, the time that he specifies is the upperbound time (ie. he will get recipes that has prep time <= the specified time).
4) Goal names are not case sensitive (eg. `g/bulk like the hulk` will work just fine)