### PR TITLE
Urgent fixes for various commands

### DIFF
--- a/src/main/java/seedu/recipe/logic/commands/DeleteIngredientCommand.java
+++ b/src/main/java/seedu/recipe/logic/commands/DeleteIngredientCommand.java
@@ -13,6 +13,7 @@ import static seedu.recipe.model.Model.PREDICATE_SHOW_ALL_RECIPES;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import seedu.recipe.commons.core.Messages;
 import seedu.recipe.commons.core.index.Index;
@@ -46,6 +47,10 @@ public class DeleteIngredientCommand extends Command {
             + PREFIX_INGREDIENT_OTHER + "Honeydew";
 
     public static final String MESSAGE_ADD_INGREDIENTS_SUCCESS = "Successfully deleted ingredient(s) from %1$s!";
+    public static final String MESSAGE_DELETING_TOO_MANY_INGREDIENTS = "Attempting to delete all ingredients or "
+            + "more ingredients than %1$s has. Ingredients list cannot be empty!";
+    public static final String MESSAGE_NO_SUCH_INGREDIENT = "%1$s is either not %2$s ingredient "
+            + "or it does not exist in %3$s!";
 
     private final Index index;
     private final EditCommand.EditRecipeDescriptor editRecipeDescriptor;
@@ -70,6 +75,23 @@ public class DeleteIngredientCommand extends Command {
 
         Recipe recipeToEdit = lastShownList.get(index.getZeroBased());
 
+        int numberOfCurrentIngredients = recipeToEdit.getTotalNumberOfIngredients();
+        AtomicInteger numberOfIngredientsToDelete = new AtomicInteger(0);
+        editRecipeDescriptor.getGrains()
+                .ifPresent(grainSet -> numberOfIngredientsToDelete.addAndGet(grainSet.size()));
+        editRecipeDescriptor.getVegetables()
+                .ifPresent(vegetableSet -> numberOfIngredientsToDelete.addAndGet(vegetableSet.size()));
+        editRecipeDescriptor.getProteins()
+                .ifPresent(proteinSet -> numberOfIngredientsToDelete.addAndGet(proteinSet.size()));
+        editRecipeDescriptor.getFruits()
+                .ifPresent(fruitSet -> numberOfIngredientsToDelete.addAndGet(fruitSet.size()));
+        editRecipeDescriptor.getOthers()
+                .ifPresent(otherSet -> numberOfIngredientsToDelete.addAndGet(otherSet.size()));
+        if (numberOfIngredientsToDelete.get() >= numberOfCurrentIngredients) {
+            throw new CommandException(
+                    String.format(MESSAGE_DELETING_TOO_MANY_INGREDIENTS, recipeToEdit.getName().toString()));
+        }
+
         updateGrainsList(recipeToEdit, editRecipeDescriptor);
         updateVegetablesList(recipeToEdit, editRecipeDescriptor);
         updateProteinsList(recipeToEdit, editRecipeDescriptor);
@@ -86,13 +108,22 @@ public class DeleteIngredientCommand extends Command {
 
     /**
      * Removes the specified {@code Grain} ingredient(s) from the current list of grains.
-     * If the specified grain ingredient(s) do not exist in the current list, nothing happens.
+     * If the specified grain ingredient(s) do not exist in the current list, CommandException is thrown.
      */
-    public void updateGrainsList(Recipe recipeToEdit, EditCommand.EditRecipeDescriptor editRecipeDescriptor) {
+    public void updateGrainsList(Recipe recipeToEdit, EditCommand.EditRecipeDescriptor editRecipeDescriptor)
+            throws CommandException {
         if (editRecipeDescriptor.getGrains().isPresent()) {
             Set<Grain> grainsToDelete = new TreeSet<>(editRecipeDescriptor.getGrains().get());
             Set<Grain> currentGrainsList = new TreeSet<>(recipeToEdit.getGrains());
-            currentGrainsList.removeIf(grainsToDelete::contains);
+            for (Grain grain : grainsToDelete) {
+                if (currentGrainsList.contains(grain)) {
+                    currentGrainsList.remove(grain);
+                } else {
+                    throw new CommandException(
+                            String.format(MESSAGE_NO_SUCH_INGREDIENT,
+                                    grain, "a grain", recipeToEdit.getName().toString()));
+                }
+            }
             editRecipeDescriptor.setGrains(currentGrainsList);
         } else {
             editRecipeDescriptor.setGrains(recipeToEdit.getGrains());
@@ -101,13 +132,22 @@ public class DeleteIngredientCommand extends Command {
 
     /**
      * Removes the specified {@code Vegetable} ingredient(s) from the current list of vegetables.
-     * If the specified vegetable ingredient(s) do not exist in the current list, nothing happens.
+     * If the specified vegetable ingredient(s) do not exist in the current list, CommandException is thrown.
      */
-    public void updateVegetablesList(Recipe recipeToEdit, EditCommand.EditRecipeDescriptor editRecipeDescriptor) {
+    public void updateVegetablesList(Recipe recipeToEdit, EditCommand.EditRecipeDescriptor editRecipeDescriptor)
+            throws CommandException {
         if (editRecipeDescriptor.getVegetables().isPresent()) {
             Set<Vegetable> vegetablesToDelete = new TreeSet<>(editRecipeDescriptor.getVegetables().get());
             Set<Vegetable> currentVegetablesList = new TreeSet<>(recipeToEdit.getVegetables());
-            currentVegetablesList.removeIf(vegetablesToDelete::contains);
+            for (Vegetable vegetable : vegetablesToDelete) {
+                if (currentVegetablesList.contains(vegetable)) {
+                    currentVegetablesList.remove(vegetable);
+                } else {
+                    throw new CommandException(
+                            String.format(MESSAGE_NO_SUCH_INGREDIENT,
+                                    vegetable, "a vegetable", recipeToEdit.getName().toString()));
+                }
+            }
             editRecipeDescriptor.setVegetables(currentVegetablesList);
         } else {
             editRecipeDescriptor.setVegetables(recipeToEdit.getVegetables());
@@ -116,13 +156,22 @@ public class DeleteIngredientCommand extends Command {
 
     /**
      * Removes the specified {@code Protein} ingredient(s) from the current list of proteins.
-     * If the specified protein ingredient(s) do not exist in the current list, nothing happens.
+     * If the specified protein ingredient(s) do not exist in the current list, CommandException is thrown.
      */
-    public void updateProteinsList(Recipe recipeToEdit, EditCommand.EditRecipeDescriptor editRecipeDescriptor) {
+    public void updateProteinsList(Recipe recipeToEdit, EditCommand.EditRecipeDescriptor editRecipeDescriptor)
+            throws CommandException {
         if (editRecipeDescriptor.getProteins().isPresent()) {
             Set<Protein> proteinsToDelete = new TreeSet<>(editRecipeDescriptor.getProteins().get());
             Set<Protein> currentProteinsList = new TreeSet<>(recipeToEdit.getProteins());
-            currentProteinsList.removeIf(proteinsToDelete::contains);
+            for (Protein protein : proteinsToDelete) {
+                if (currentProteinsList.contains(protein)) {
+                    currentProteinsList.remove(protein);
+                } else {
+                    throw new CommandException(
+                            String.format(MESSAGE_NO_SUCH_INGREDIENT,
+                                    protein, "a protein", recipeToEdit.getName().toString()));
+                }
+            }
             editRecipeDescriptor.setProteins(currentProteinsList);
         } else {
             editRecipeDescriptor.setProteins(recipeToEdit.getProteins());
@@ -131,13 +180,22 @@ public class DeleteIngredientCommand extends Command {
 
     /**
      * Removes the specified {@code Fruit} ingredient(s) from the current list of fruits.
-     * If the specified fruit ingredient(s) do not exist in the current list, nothing happens.
+     * If the specified fruit ingredient(s) do not exist in the current list, CommandException is thrown.
      */
-    public void updateFruitsList(Recipe recipeToEdit, EditCommand.EditRecipeDescriptor editRecipeDescriptor) {
+    public void updateFruitsList(Recipe recipeToEdit, EditCommand.EditRecipeDescriptor editRecipeDescriptor)
+            throws CommandException {
         if (editRecipeDescriptor.getFruits().isPresent()) {
             Set<Fruit> fruitsToDelete = new TreeSet<>(editRecipeDescriptor.getFruits().get());
             Set<Fruit> currentFruitsList = new TreeSet<>(recipeToEdit.getFruits());
-            currentFruitsList.removeIf(fruitsToDelete::contains);
+            for (Fruit fruit : fruitsToDelete) {
+                if (currentFruitsList.contains(fruit)) {
+                    currentFruitsList.remove(fruit);
+                } else {
+                    throw new CommandException(
+                            String.format(MESSAGE_NO_SUCH_INGREDIENT,
+                                    fruit, "a fruit", recipeToEdit.getName().toString()));
+                }
+            }
             editRecipeDescriptor.setFruits(currentFruitsList);
         } else {
             editRecipeDescriptor.setFruits(recipeToEdit.getFruits());
@@ -146,13 +204,22 @@ public class DeleteIngredientCommand extends Command {
 
     /**
      * Removes the specified {@code Other} ingredient(s) from the current list of other ingredients.
-     * If the specified other ingredient(s) do not exist in the current list, nothing happens.
+     * If the specified other ingredient(s) do not exist in the current list, CommandException is thrown.
      */
-    public void updateOthersList(Recipe recipeToEdit, EditCommand.EditRecipeDescriptor editRecipeDescriptor) {
+    public void updateOthersList(Recipe recipeToEdit, EditCommand.EditRecipeDescriptor editRecipeDescriptor)
+            throws CommandException {
         if (editRecipeDescriptor.getOthers().isPresent()) {
             Set<Other> othersToDelete = new TreeSet<>(editRecipeDescriptor.getOthers().get());
             Set<Other> currentOthersList = new TreeSet<>(recipeToEdit.getOthers());
-            currentOthersList.removeIf(othersToDelete::contains);
+            for (Other other : othersToDelete) {
+                if (currentOthersList.contains(other)) {
+                    currentOthersList.remove(other);
+                } else {
+                    throw new CommandException(
+                            String.format(MESSAGE_NO_SUCH_INGREDIENT,
+                                    other, "an 'other'", recipeToEdit.getName().toString()));
+                }
+            }
             editRecipeDescriptor.setOthers(currentOthersList);
         } else {
             editRecipeDescriptor.setOthers(recipeToEdit.getOthers());

--- a/src/main/java/seedu/recipe/logic/commands/DeleteStepCommand.java
+++ b/src/main/java/seedu/recipe/logic/commands/DeleteStepCommand.java
@@ -55,7 +55,7 @@ public class DeleteStepCommand extends Command {
         Recipe recipeToEdit = lastShownList.get(index.getZeroBased());
 
         List<Step> updatedStepsList = new ArrayList<>(recipeToEdit.getSteps());
-        if (!canDeleteTargetSteps(updatedStepsList, stepNumbers)) {
+        if (stepNumbers[stepNumbers.length - 1] > updatedStepsList.size() - 1) {
             throw new CommandException(MESSAGE_INVALID_STEP_INDEX);
         }
 
@@ -70,18 +70,6 @@ public class DeleteStepCommand extends Command {
         model.commitRecipeBook();
 
         return new CommandResult(String.format(MESSAGE_ADD_STEPS_SUCCESS, recipeToEdit.getName().toString()));
-    }
-
-    /**
-     * Checks if the step number that the user wishes to delete exists within the steps list.
-     */
-    public boolean canDeleteTargetSteps(List<Step> updatedStepsList, Integer[] stepNumbers) {
-        for (int i = stepNumbers.length - 1; i >= 0; i--) {
-            if (stepNumbers[i] > updatedStepsList.size() - 1) {
-                return false;
-            }
-        }
-        return true;
     }
 
     @Override

--- a/src/main/java/seedu/recipe/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/recipe/logic/commands/EditCommand.java
@@ -66,6 +66,7 @@ public class EditCommand extends Command {
     public static final String MESSAGE_EDIT_RECIPE_SUCCESS = "Edited Recipe: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_RECIPE = "This recipe already exists in the address book.";
+    public static final String MESSAGE_CANNOT_DELETE_ALL_INGREDIENTS = "Cannot delete all ingredients!";
 
     private final Index index;
     private final EditRecipeDescriptor editRecipeDescriptor;
@@ -93,6 +94,10 @@ public class EditCommand extends Command {
 
         Recipe recipeToEdit = lastShownList.get(index.getZeroBased());
         Recipe editedRecipe = createEditedRecipe(recipeToEdit, editRecipeDescriptor);
+
+        if (editedRecipe.getTotalNumberOfIngredients() <= 0) {
+            throw new CommandException(MESSAGE_CANNOT_DELETE_ALL_INGREDIENTS);
+        }
 
         if (!recipeToEdit.isSameRecipe(editedRecipe) && model.hasRecipe(editedRecipe)) {
             throw new CommandException(MESSAGE_DUPLICATE_RECIPE);

--- a/src/main/java/seedu/recipe/logic/commands/EditIngredientCommand.java
+++ b/src/main/java/seedu/recipe/logic/commands/EditIngredientCommand.java
@@ -46,6 +46,8 @@ public class EditIngredientCommand extends Command {
             + PREFIX_INGREDIENT_OTHER + "50g, Honeydew";
 
     public static final String MESSAGE_ADD_INGREDIENTS_SUCCESS = "Successfully edited ingredient(s) in %1$s!";
+    public static final String MESSAGE_NO_SUCH_INGREDIENT = "%1$s is either not %2$s ingredient "
+            + "or it does not exist in %3$s!";
 
     private final Index index;
     private final EditCommand.EditRecipeDescriptor editRecipeDescriptor;
@@ -86,9 +88,10 @@ public class EditIngredientCommand extends Command {
 
     /**
      * Edits the quantity of the specified {@code Grain} ingredient(s) in the current list of grains.
-     * If the specified grain ingredient(s) do not exist in the current list, nothing happens.
+     * If the specified grain ingredient(s) do not exist in the current list, CommandException is thrown.
      */
-    public void updateGrainsList(Recipe recipeToEdit, EditCommand.EditRecipeDescriptor editRecipeDescriptor) {
+    public void updateGrainsList(Recipe recipeToEdit, EditCommand.EditRecipeDescriptor editRecipeDescriptor)
+            throws CommandException {
         if (editRecipeDescriptor.getGrains().isPresent()) {
             Set<Grain> grainsToEdit = new TreeSet<>(editRecipeDescriptor.getGrains().get());
             Set<Grain> currentGrainsList = new TreeSet<>(recipeToEdit.getGrains());
@@ -96,6 +99,10 @@ public class EditIngredientCommand extends Command {
                 if (currentGrainsList.contains(grain)) {
                     currentGrainsList.remove(grain);
                     currentGrainsList.add(grain);
+                } else {
+                    throw new CommandException(
+                            String.format(MESSAGE_NO_SUCH_INGREDIENT,
+                                    grain, "a grain", recipeToEdit.getName().toString()));
                 }
             }
             editRecipeDescriptor.setGrains(currentGrainsList);
@@ -106,9 +113,10 @@ public class EditIngredientCommand extends Command {
 
     /**
      * Edits the quantity of the specified {@code Vegetable} ingredient(s) in the current list of vegetables.
-     * If the specified vegetable ingredient(s) do not exist in the current list, nothing happens.
+     * If the specified vegetable ingredient(s) do not exist in the current list, CommandException is thrown.
      */
-    public void updateVegetablesList(Recipe recipeToEdit, EditCommand.EditRecipeDescriptor editRecipeDescriptor) {
+    public void updateVegetablesList(Recipe recipeToEdit, EditCommand.EditRecipeDescriptor editRecipeDescriptor)
+            throws CommandException {
         if (editRecipeDescriptor.getVegetables().isPresent()) {
             Set<Vegetable> vegetablesToEdit = new TreeSet<>(editRecipeDescriptor.getVegetables().get());
             Set<Vegetable> currentVegetablesList = new TreeSet<>(recipeToEdit.getVegetables());
@@ -116,6 +124,10 @@ public class EditIngredientCommand extends Command {
                 if (currentVegetablesList.contains(vegetable)) {
                     currentVegetablesList.remove(vegetable);
                     currentVegetablesList.add(vegetable);
+                } else {
+                    throw new CommandException(
+                            String.format(MESSAGE_NO_SUCH_INGREDIENT,
+                                    vegetable, "a vegetable", recipeToEdit.getName().toString()));
                 }
             }
             editRecipeDescriptor.setVegetables(currentVegetablesList);
@@ -126,9 +138,10 @@ public class EditIngredientCommand extends Command {
 
     /**
      * Edits the quantity of the specified {@code Protein} ingredient(s) in the current list of proteins.
-     * If the specified protein ingredient(s) do not exist in the current list, nothing happens.
+     * If the specified protein ingredient(s) do not exist in the current list, CommandException is thrown.
      */
-    public void updateProteinsList(Recipe recipeToEdit, EditCommand.EditRecipeDescriptor editRecipeDescriptor) {
+    public void updateProteinsList(Recipe recipeToEdit, EditCommand.EditRecipeDescriptor editRecipeDescriptor)
+            throws CommandException {
         if (editRecipeDescriptor.getProteins().isPresent()) {
             Set<Protein> proteinsToEdit = new TreeSet<>(editRecipeDescriptor.getProteins().get());
             Set<Protein> currentProteinsList = new TreeSet<>(recipeToEdit.getProteins());
@@ -136,6 +149,10 @@ public class EditIngredientCommand extends Command {
                 if (currentProteinsList.contains(protein)) {
                     currentProteinsList.remove(protein);
                     currentProteinsList.add(protein);
+                } else {
+                    throw new CommandException(
+                            String.format(MESSAGE_NO_SUCH_INGREDIENT,
+                                    protein, "a protein", recipeToEdit.getName().toString()));
                 }
             }
             editRecipeDescriptor.setProteins(currentProteinsList);
@@ -146,9 +163,10 @@ public class EditIngredientCommand extends Command {
 
     /**
      * Edits the quantity of the specified {@code Fruit} ingredient(s) in the current list of fruits.
-     * If the specified fruit ingredient(s) do not exist in the current list, nothing happens.
+     * If the specified fruit ingredient(s) do not exist in the current list, CommandException is thrown.
      */
-    public void updateFruitsList(Recipe recipeToEdit, EditCommand.EditRecipeDescriptor editRecipeDescriptor) {
+    public void updateFruitsList(Recipe recipeToEdit, EditCommand.EditRecipeDescriptor editRecipeDescriptor)
+            throws CommandException {
         if (editRecipeDescriptor.getFruits().isPresent()) {
             Set<Fruit> fruitsToEdit = new TreeSet<>(editRecipeDescriptor.getFruits().get());
             Set<Fruit> currentFruitsList = new TreeSet<>(recipeToEdit.getFruits());
@@ -156,6 +174,10 @@ public class EditIngredientCommand extends Command {
                 if (currentFruitsList.contains(fruit)) {
                     currentFruitsList.remove(fruit);
                     currentFruitsList.add(fruit);
+                } else {
+                    throw new CommandException(
+                            String.format(MESSAGE_NO_SUCH_INGREDIENT,
+                                    fruit, "a fruit", recipeToEdit.getName().toString()));
                 }
             }
             editRecipeDescriptor.setFruits(currentFruitsList);
@@ -166,9 +188,10 @@ public class EditIngredientCommand extends Command {
 
     /**
      * Edits the quantity of the specified {@code Other} ingredient(s) in the current list of other ingredients.
-     * If the specified other ingredient(s) do not exist in the current list, nothing happens.
+     * If the specified other ingredient(s) do not exist in the current list, CommandException is thrown.
      */
-    public void updateOthersList(Recipe recipeToEdit, EditCommand.EditRecipeDescriptor editRecipeDescriptor) {
+    public void updateOthersList(Recipe recipeToEdit, EditCommand.EditRecipeDescriptor editRecipeDescriptor)
+            throws CommandException {
         if (editRecipeDescriptor.getOthers().isPresent()) {
             Set<Other> othersToEdit = new TreeSet<>(editRecipeDescriptor.getOthers().get());
             Set<Other> currentOthersList = new TreeSet<>(recipeToEdit.getOthers());
@@ -176,6 +199,10 @@ public class EditIngredientCommand extends Command {
                 if (currentOthersList.contains(other)) {
                     currentOthersList.remove(other);
                     currentOthersList.add(other);
+                } else {
+                    throw new CommandException(
+                            String.format(MESSAGE_NO_SUCH_INGREDIENT,
+                                    other, "an 'other'", recipeToEdit.getName().toString()));
                 }
             }
             editRecipeDescriptor.setOthers(currentOthersList);

--- a/src/main/java/seedu/recipe/logic/parser/DeleteIngredientCommandParser.java
+++ b/src/main/java/seedu/recipe/logic/parser/DeleteIngredientCommandParser.java
@@ -52,7 +52,8 @@ public class DeleteIngredientCommandParser implements Parser<DeleteIngredientCom
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
-            throw new ParseException(ParserUtil.MESSAGE_INVALID_INDEX);
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteIngredientCommand.MESSAGE_USAGE), pe);
         }
 
         EditRecipeDescriptor editRecipeDescriptor = new EditRecipeDescriptor();

--- a/src/main/java/seedu/recipe/logic/parser/EditIngredientCommandParser.java
+++ b/src/main/java/seedu/recipe/logic/parser/EditIngredientCommandParser.java
@@ -52,7 +52,8 @@ public class EditIngredientCommandParser implements Parser<EditIngredientCommand
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
-            throw new ParseException(ParserUtil.MESSAGE_INVALID_INDEX);
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditIngredientCommand.MESSAGE_USAGE), pe);
         }
 
         EditRecipeDescriptor editRecipeDescriptor = new EditRecipeDescriptor();

--- a/src/main/java/seedu/recipe/logic/parser/EditStepCommandParser.java
+++ b/src/main/java/seedu/recipe/logic/parser/EditStepCommandParser.java
@@ -37,7 +37,7 @@ public class EditStepCommandParser implements Parser<EditStepCommand> {
             index = ParserUtil.parseIndex(argsArray[0]);
             stepNumber = ParserUtil.parseIndex(argsArray[1]).getZeroBased();
         } catch (ParseException pe) {
-            throw new ParseException(ParserUtil.MESSAGE_INVALID_INDEX);
+            throw new ParseException(pe.getMessage());
         } catch (ArrayIndexOutOfBoundsException aioobe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditStepCommand.MESSAGE_USAGE));
         }

--- a/src/main/java/seedu/recipe/logic/parser/EditStepCommandParser.java
+++ b/src/main/java/seedu/recipe/logic/parser/EditStepCommandParser.java
@@ -36,8 +36,6 @@ public class EditStepCommandParser implements Parser<EditStepCommand> {
         try {
             index = ParserUtil.parseIndex(argsArray[0]);
             stepNumber = ParserUtil.parseIndex(argsArray[1]).getZeroBased();
-        } catch (ParseException pe) {
-            throw new ParseException(pe.getMessage());
         } catch (ArrayIndexOutOfBoundsException aioobe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditStepCommand.MESSAGE_USAGE));
         }

--- a/src/main/java/seedu/recipe/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/recipe/logic/parser/ParserUtil.java
@@ -67,10 +67,10 @@ public class ParserUtil {
             }
             toSort[i] = Integer.parseInt(index);
         }
-        Arrays.sort(toSort);
+        toSort = Arrays.stream(toSort).distinct().sorted().toArray(Integer[]::new);
 
-        Index[] indices = new Index[len];
-        for (int i = 0; i < len; i++) {
+        Index[] indices = new Index[toSort.length];
+        for (int i = 0; i < indices.length; i++) {
             indices[i] = Index.fromOneBased(toSort[i]);
         }
         return indices;

--- a/src/main/java/seedu/recipe/model/recipe/Recipe.java
+++ b/src/main/java/seedu/recipe/model/recipe/Recipe.java
@@ -127,6 +127,13 @@ public class Recipe {
     }
 
     /**
+     * Returns the total number of ingredients that this recipe has.
+     */
+    public int getTotalNumberOfIngredients() {
+        return grains.size() + vegetables.size() + proteins.size() + fruits.size() + others.size();
+    }
+
+    /**
      * Returns true if both recipes of the same name have at least one other identity field that is the same.
      * This defines a weaker notion of equality between two recipes.
      */

--- a/src/main/java/seedu/recipe/model/recipe/ingredient/Ingredient.java
+++ b/src/main/java/seedu/recipe/model/recipe/ingredient/Ingredient.java
@@ -70,9 +70,9 @@ public abstract class Ingredient implements Comparable<Ingredient> {
     @Override
     public String toString() {
         if (quantity == null) {
-            return "";
+            return ingredientName;
         }
-        return quantity + " " + ingredientName + " ";
+        return quantity + " " + ingredientName;
     }
 
     @Override

--- a/src/main/java/seedu/recipe/ui/RecipeCard.java
+++ b/src/main/java/seedu/recipe/ui/RecipeCard.java
@@ -104,19 +104,21 @@ public class RecipeCard extends UiPart<Region> {
         recipe.getOthers().forEach(other -> others.getChildren().add(new Label(other.toString())));
         others.getChildren().forEach(other -> other.setStyle(styleIngredientsAndSteps));
 
-        stepsHeader.setText("Steps");
-        stepsHeader.setUnderline(true);
-        stepsHeader.setPadding(new Insets(10, 0, 0, 0));
+        if (!recipe.getSteps().isEmpty()) {
+            stepsHeader.setText("Steps");
+            stepsHeader.setUnderline(true);
+            stepsHeader.setPadding(new Insets(10, 0, 0, 0));
 
-        // Calculates step number and displays with along with the step
-        AtomicInteger stepNumber = new AtomicInteger(1);
-        recipe.getSteps().forEach(step -> {
-            Label stepLabel = new Label("Step " + stepNumber.getAndIncrement() + ": " + step.value);
-            stepLabel.setWrapText(true);
-            stepLabel.setStyle(styleIngredientsAndSteps);
-            steps.getChildren().add(stepLabel);
-        });
-        steps.setSpacing(5);
+            // Calculates step number and displays with along with the step
+            AtomicInteger stepNumber = new AtomicInteger(1);
+            recipe.getSteps().forEach(step -> {
+                Label stepLabel = new Label("Step " + stepNumber.getAndIncrement() + ": " + step.value);
+                stepLabel.setWrapText(true);
+                stepLabel.setStyle(styleIngredientsAndSteps);
+                steps.getChildren().add(stepLabel);
+            });
+            steps.setSpacing(5);
+        }
 
     }
 


### PR DESCRIPTION
Hi, I realised that there were certain undesirable behavior for various commands. I've listed the fixes below:

- `deleteIngredient` used to delete whatever ingredients it can find and not do anything if it encounters an ingredient that does not exist in ingredient list. Now, it will throw an error and not delete anything at all until the user gives accurate input.

- `deleteIngredient` used to not check if the user is attempting to delete all ingredients (which is not an allowed scenario). Now, it will check if the user is attempting to do so and throw an error.

- `deleteStep` and delete used to not check if the user has input distinct index numbers. Now, it will automatically remove repeated index numbers and carry on with the delete operation.

- `editIngredient` used to edit the ingredient if it can find it and not do anything if it cannot find the ingredient in the ingredient list. Now, it will throw an error until the user gives accurate input.

- `edit` used to be able to delete all ingredients if the user entered: `edit 1 ig/ iv/ ip/ if/ io/` which is undesirable behavior since we defined recipe name, prep time, and ingredients as compulsory fields. Now, the app will check if an edit command will cause the ingredients list to become empty. If it will, then an error will be thrown and no edits will be made. However, note that the ability to delete entire ingredient field(s) by entering `edit 1 ig/ ip/` is still there. It will only be denied if executing the command will cause the ingredients list to become empty.

**To discuss:** Regarding the last point, I would like to ask if we should throw an error if the user leaves any ingredient field blank during `edit`. Currently, if the user types `edit 1 n/`, `edit 1 t/`, or `edit 1 s/`, errors will be thrown but this behavior doesn't apply to ingredient prefixes.